### PR TITLE
Blog comments dated

### DIFF
--- a/blog/blog_comments.php
+++ b/blog/blog_comments.php
@@ -115,20 +115,18 @@ if (count($comments) > 0) {
 
 <?php 
 
-/*
-if (isset($_GET['saved']) && $_GET['saved'] == 'no') {
-	echo '<div id="commentAdd">'; 
-} else {
+// only show comments if the post is less than a defined age.
+if ($postAge > $COMMENT_EXPIRE) {
 	echo 
 		'<div>
-			<h4>Adding comments is temporarily disabled.</h4>'; 
-}
-*/
+			<h4>Adding comments has now expired for this post.</h4>
+		</div>'; 
+} else {
+	echo '<div id="commentAdd">'; 
 
 ?>
 
-	<div>
-		<h4>Add a comment</h4>
+	<h4>Add a comment</h4>
 
 <?php
 
@@ -261,5 +259,12 @@ if (isset($validCaptcha) && $validCaptcha == 'invalid') {
 			</fieldset>
 		</form>
 	</div> <!-- end commentAdd -->
+
+<?php
+
+}
+
+?>
+
 </div>
 <!-- END blog_comments -->

--- a/blog/blog_primary.php
+++ b/blog/blog_primary.php
@@ -7,11 +7,13 @@ if (isset($_GET['postId']) && $_GET['postId'] != '') {
 	$postId = $_GET['postId']; 
 	$idArray = explode('-', $postId); 
 	$postId = array_pop($idArray); 
-		
-	// echo 'postId = '.$_GET['postId']; 
-	
 	$post = $weblog->getPost($postId);
-	
+
+	// calculate age of post
+	$postDate = new DateTime($post['timestamp']);
+	$now = new DateTime();
+	$postAge = $postDate->diff($now)->format('%a'); // in days
+
 	if (isset($post['title'])) {
 		$postTitle = htmlspecialchars_decode($post['title']); 
 	} else {

--- a/constants/environment.php
+++ b/constants/environment.php
@@ -10,6 +10,8 @@ if ($_SERVER['SERVER_NAME'] == 'davidtrussler.net') {
 	$DOC_ROOT = '/Library/WebServer/Documents/dtNet/'; 
 }
 
+$COMMENT_EXPIRE = 243; // number of days until comments are disabled
+
 /*
 // local server
 $DOC_ROOT = '/home/davidtrussler/public_html/dtNet'; 

--- a/constants/environment.php
+++ b/constants/environment.php
@@ -1,25 +1,13 @@
 <?php
 
-// echo 'SERVER_NAME: '.$_SERVER['SERVER_NAME']; 
-
 if ($_SERVER['SERVER_NAME'] == 'davidtrussler.net') {
-	$SERVER_ROOT = 'http://davidtrussler.net'; 
-	$DOC_ROOT = '/home/futuragr/public_html/davidtrussler'; 
+	$SERVER_ROOT = 'http://davidtrussler.net/'; 
+	$DOC_ROOT = '/home/futuragr/public_html/davidtrussler/'; 
 } else {
-	$SERVER_ROOT = 'http://localhost/dtNet/'; 
-	$DOC_ROOT = '/Library/WebServer/Documents/dtNet/'; 
+	$SERVER_ROOT = 'http://localhost/dtNet/';
+	$DOC_ROOT = '/Library/WebServer/Documents/dtNet/';
 }
 
 $COMMENT_EXPIRE = 243; // number of days until comments are disabled
-
-/*
-// local server
-$DOC_ROOT = '/home/davidtrussler/public_html/dtNet'; 
-$SERVER_ROOT = 'http://'.$_SERVER['SERVER_NAME'].'/~davidtrussler/dtNet';
-
-// remote server
-$DOC_ROOT = '/home/futuragr/public_html/davidtrussler'; 
-$SERVER_ROOT = 'http://'.$_SERVER['SERVER_NAME'].'/~futuragr/davidtrussler';
-*/
 
 ?>

--- a/includes/commonHeader.php
+++ b/includes/commonHeader.php
@@ -9,27 +9,6 @@ $pageArray = explode('.', $page);
 // set the timezone for date-based calculations
 date_default_timezone_set('Europe/London'); 
 
-/*
-if ($SERVER_ROOT == 'http://davidtrussler.net/~futuragr/davidtrussler') {
-	$localRoot = 'http://davidtrussler.net'; 
-	$docRoot = $DOC_ROOT; 
-} else {
-	$localRoot = 'http://localhost/dtNet/'; 
-	$docRoot = '/Library/WebServer/Documents/dtNet/'; 
-}
-*/
-
-if ($_SERVER['SERVER_NAME'] == 'davidtrussler.net') {
-	$SERVER_ROOT = 'http://davidtrussler.net'; 
-	$DOC_ROOT = '/home/futuragr/public_html/davidtrussler'; 
-} else {
-	$SERVER_ROOT = 'http://localhost/dtNet/'; 
-	$DOC_ROOT = '/Library/WebServer/Documents/dtNet/'; 
-}
-
-// echo 'self = '.$self; 
-// echo 'SERVER_ROOT = '.$SERVER_ROOT; 
-
 $link_array = array (
 	'home' => 'home', 
 	'web' => 'web', 

--- a/includes/commonHeader.php
+++ b/includes/commonHeader.php
@@ -6,6 +6,9 @@ $page = array_pop($selfArray);
 $root = join('/', $selfArray).'/'; 
 $pageArray = explode('.', $page); 
 
+// set the timezone for date-based calculations
+date_default_timezone_set('Europe/London'); 
+
 /*
 if ($SERVER_ROOT == 'http://davidtrussler.net/~futuragr/davidtrussler') {
 	$localRoot = 'http://davidtrussler.net'; 


### PR DESCRIPTION
This was added in an attempt to close down spam contributions to the site via the blog comments section. Initially the number of days before comments are disabled for a post is measured by the date of the post when the hackers last struck: 243 days, though this will doubtless need to be changed over time.  Or they will just target newer posts. Let's see ...
